### PR TITLE
Add AGENTS.md with development environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+**vue-pincher** is a Vue 3 image cropper component library with a bundled demo app. It is a single npm package (not a monorepo).
+
+### Project layout
+
+- `lib/` — Library source code (published to npm): component, manipulator, crop logic, input handler, and their tests.
+- `src/` — Demo/dev application used for local development and manual testing.
+- `dist/` — Build output (git-ignored).
+
+### Key commands
+
+All commands are defined in `package.json` scripts:
+
+| Task | Command |
+|---|---|
+| Install deps | `npm install` |
+| Dev server | `npm start` (Vite on port 5173) |
+| Lint | `npm run lint` |
+| Test | `npm test` (Vitest + coverage) |
+| Build | `npm run build` (Vite lib build + vue-tsc declarations) |
+
+### Notes
+
+- The pre-commit hook (`.husky/pre-commit`) runs `npm run lint` and `npm run test` before every commit. Both must pass.
+- Tests use `happy-dom` as the DOM environment — no browser required for automated tests.
+- No databases, Docker, or external services are needed. The project is entirely client-side.
+- Node 22.x is the primary CI version; Node 20.x is also tested.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for development environment setup.

## What's included

- Project layout overview (`lib/` for library, `src/` for demo app)
- Key commands table (install, dev server, lint, test, build)
- Notes on pre-commit hooks, test environment, and CI configuration

## Development environment verification

All checks pass on Node.js v22:

- **Lint**: `npm run lint` — clean
- **Tests**: `npm test` — 86/86 tests passing with coverage
- **Build**: `npm run build` — library + type declarations
- **Dev server**: `npm start` — Vite dev server on port 5173

### Demo

[vue_pincher_demo_zoom_pan_fill.mp4](https://cursor.com/agents/bc-532713fd-4b21-47b1-953c-842c8af5e5d8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvue_pincher_demo_zoom_pan_fill.mp4)

Demo of the Vue Pincher image cropper showing zoom, pan, and auto-fill features working in the dev environment.

[Vue Pincher app loaded](https://cursor.com/agents/bc-532713fd-4b21-47b1-953c-842c8af5e5d8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvue_pincher_loaded.webp)
[Vue Pincher zoomed in](https://cursor.com/agents/bc-532713fd-4b21-47b1-953c-842c8af5e5d8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvue_pincher_zoomed.webp)
[Vue Pincher fill with attention](https://cursor.com/agents/bc-532713fd-4b21-47b1-953c-842c8af5e5d8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvue_pincher_fill_attention.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-532713fd-4b21-47b1-953c-842c8af5e5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-532713fd-4b21-47b1-953c-842c8af5e5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

